### PR TITLE
fix path traversal cases

### DIFF
--- a/lib/static.js
+++ b/lib/static.js
@@ -1,5 +1,5 @@
 import File from './file.js';
-import { normalize } from 'path';
+import {normalize} from 'path';
 
 export default class Static {
   constructor () {
@@ -8,10 +8,13 @@ export default class Static {
   }
 
   async dispatch (ctx) {
-    const path = normalize(ctx.req.path);
-    if (path === null || !path.startsWith(this.prefix) || path.match(/\\/)) return false;
-    const parts = path.replace(this.prefix, '').split('/');
+    const unsafePath = ctx.req.path;
+    if (unsafePath === null || unsafePath.startsWith(this.prefix) !== true) return false;
 
+    const path = normalize(unsafePath);
+    if (path.includes('\\')) return false;
+
+    const parts = path.replace(this.prefix, '').split('/');
     for (const dir of this.publicPaths) {
       const file = new File(dir, ...parts);
       if (!await file.isReadable()) continue;

--- a/lib/static.js
+++ b/lib/static.js
@@ -1,4 +1,5 @@
 import File from './file.js';
+import { normalize } from 'path';
 
 export default class Static {
   constructor () {
@@ -7,8 +8,8 @@ export default class Static {
   }
 
   async dispatch (ctx) {
-    const path = ctx.req.path;
-    if (path === null || !path.startsWith(this.prefix)) return false;
+    const path = normalize(ctx.req.path);
+    if (path === null || !path.startsWith(this.prefix) || path.match(/\\/)) return false;
     const parts = path.replace(this.prefix, '').split('/');
 
     for (const dir of this.publicPaths) {

--- a/lib/static.js
+++ b/lib/static.js
@@ -12,7 +12,7 @@ export default class Static {
     if (unsafePath === null || unsafePath.startsWith(this.prefix) !== true) return false;
 
     const path = normalize(unsafePath);
-    if (path.includes('\\')) return false;
+    if (path.includes('..\\')) return false;
 
     const parts = path.replace(this.prefix, '').split('/');
     for (const dir of this.publicPaths) {

--- a/test/static-app.js
+++ b/test/static-app.js
@@ -7,7 +7,9 @@ t.test('Static app', async t => {
   await t.test('0', async t => {
     (await client.getOk('/public/0')).statusIs(200).headerIs('Content-Length', '1').bodyIs('0');
     (await client.getOk('/0')).statusIs(200).headerIs('Content-Length', '4').bodyIs('Zero');
-    (await client.getOk('/public/../lib/mojo.js')).statusIs(404);
+    (await client.getOk('/public/../../lib/mojo.js')).statusIs(404); // this test could be a false negative
+    (await client.getOk('/public/..%2F..%2Flib/mojo.js')).statusIs(404); // actual traversal test
+    (await client.getOk('/public/..%5C..%5Clib/mojo.js')).statusIs(404); // windows backslash test
   });
 
   await t.test('Range', async t => {

--- a/test/static-app.js
+++ b/test/static-app.js
@@ -7,9 +7,12 @@ t.test('Static app', async t => {
   await t.test('0', async t => {
     (await client.getOk('/public/0')).statusIs(200).headerIs('Content-Length', '1').bodyIs('0');
     (await client.getOk('/0')).statusIs(200).headerIs('Content-Length', '4').bodyIs('Zero');
-    (await client.getOk('/public/../../lib/mojo.js')).statusIs(404); // this test could be a false negative
-    (await client.getOk('/public/..%2F..%2Flib/mojo.js')).statusIs(404); // actual traversal test
-    (await client.getOk('/public/..%5C..%5Clib/mojo.js')).statusIs(404); // windows backslash test
+  });
+
+  await t.test('Directory traversal', async t => {
+    (await client.getOk('/public/../../lib/mojo.js')).statusIs(404);
+    (await client.getOk('/public/..%2F..%2Flib/mojo.js')).statusIs(404);
+    (await client.getOk('/public/..%5C..%5Clib/mojo.js')).statusIs(404);
   });
 
   await t.test('Range', async t => {


### PR DESCRIPTION
# Description

#### This PR solves some cases of urls that are allowed to traverse root (public) dirs on a mojo.js app.

## Some considerations to understand the PR:

### 1) In order to test a path traversal, you need to circumvent http client's automatic resolution of '../' patterns
Otherwise you will be testing your http client ability to resolve a path. This happens not only with browsers, but also with other clients like curl, wget, or even with mojo.js cli (get) command. (This is easily confirmed capturing http traffic with tcpdump or with wireshark).

To avoid this problem, you can use a ```perl -Mojo``` oneliner. To test a path traversal over root directory (/public), try this:

- start a mojo app server in one terminal:

```shell
node test/support/static-app/index.js server
``` 
- then from another window you can test the following path traversal (will succeed before you apply this PR):

```shell
perl -Mojo -e 'say g("http://localhost:3000/public/../../lib/mojo.js")->body'
```

### 2) current test for path traversal has a couple issues: 

https://github.com/mojolicious/mojo.js/blob/45577ef40ca07cec9257e90ebcd4662489738b87/test/static-app.js#L10

I guess there is a typo there and the url should be '/public/../../lib/mojo.js', as the "public" target directory is the mojo.js/vendor/public directory, so you will need to traverse twice in order to get mojo.js home directory.

But the real problem is that the test itself will anyway pass (i.e. you get a false negative), because the url that is exposed to the server request is parsed by the URL() method inside lib/client.js _filterConfig function, and that method seems to do some normalization in the input url, just like other clients (browsers, curl, mojo.js's cli) do.

So eventually the url that http(s)'s request event will expose to the mojo app server will be '/lib/mojo.js', (i.e. with all '../' parts removed) and that will always give you a 404 response because it doesn't start with the right prefix ('/public').

With current tests, you can url encode '/' like %2F, or '../' like %2E%2E%2F. You can do the same to reproduce the traversals from a browser (i.e. http://public/..%2F..%2Flib/mojo.js will traverse root on current version)

### 3) backslash traversal can be an issue on windows servers

According to RFC 3986, backlash is an allowed char (i.e. not a reserved character). Backslash however is problematic because is the windows file separator, and also because lot of people just confuse it with the regular slash when typing. 

So in general, support on urls is not a very well defined issue.

Also note that browsers translates all backslashes to regular slashes because as mentioned before many people just keep confusing them anyway.

In this PR I opted to just block them for static files, just as we did some time ago in mojo.pl, mainly to avoid possible path traversals in windows.

### 4) performance before and after:

Doesn't seem to be affected. reqs/sec varies between 21k and 26k for both cases (main vs path-traversals branches), and latency is always among 4 mS.

(in other terminal, first checked out to the intended version, then command run was ```node benchmarks/hello/hello-mojo.js server``` always).

Look at the git branch before the wrk command to differentiate which version was checked out in each case.

```shell
 daniel@MBP-daniel  ~/mojo.js   main  wrk -c 100 -d 10s http://127.0.0.1:3000
Running 10s test @ http://127.0.0.1:3000
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     5.01ms    2.14ms  43.48ms   91.94%
    Req/Sec    10.29k     2.20k   12.43k    83.00%
  204738 requests in 10.01s, 34.17MB read
Requests/sec:  20457.64
Transfer/sec:      3.41MB
 daniel@MBP-daniel  ~/mojo.js   main  wrk -c 100 -d 10s http://127.0.0.1:3000
Running 10s test @ http://127.0.0.1:3000
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     4.74ms    0.94ms  19.08ms   87.55%
    Req/Sec    10.61k     1.20k   11.85k    88.00%
  211175 requests in 10.01s, 35.24MB read
Requests/sec:  21103.74
Transfer/sec:      3.52MB
 daniel@MBP-daniel  ~/mojo.js   main  wrk -c 100 -d 10s http://127.0.0.1:3000
Running 10s test @ http://127.0.0.1:3000
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     4.32ms    0.87ms  16.64ms   89.33%
    Req/Sec    11.62k     0.90k   12.99k    85.50%
  231316 requests in 10.01s, 38.61MB read
Requests/sec:  23117.21
Transfer/sec:      3.86MB
 daniel@MBP-daniel  ~/mojo.js   main  wrk -c 100 -d 10s http://127.0.0.1:3000
Running 10s test @ http://127.0.0.1:3000
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     4.06ms    1.93ms  47.26ms   93.77%
    Req/Sec    12.77k     2.54k   14.85k    83.50%
  254301 requests in 10.00s, 42.44MB read
Requests/sec:  25421.85
Transfer/sec:      4.24MB
 daniel@MBP-daniel  ~/mojo.js   path-traversals  wrk -c 100 -d 10s http://127.0.0.1:3000
Running 10s test @ http://127.0.0.1:3000
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.80ms    0.87ms  25.70ms   91.54%
    Req/Sec    13.27k     1.39k   14.46k    93.00%
  264106 requests in 10.00s, 44.08MB read
Requests/sec:  26404.61
Transfer/sec:      4.41MB
 daniel@MBP-daniel  ~/mojo.js   path-traversals  wrk -c 100 -d 10s http://127.0.0.1:3000
Running 10s test @ http://127.0.0.1:3000
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.87ms  794.82us  15.79ms   87.62%
    Req/Sec    12.98k     1.41k   14.20k    90.00%
  258322 requests in 10.00s, 43.11MB read
Requests/sec:  25826.89
Transfer/sec:      4.31MB
 daniel@MBP-daniel  ~/mojo.js   path-traversals  wrk -c 100 -d 10s http://127.0.0.1:3000
Running 10s test @ http://127.0.0.1:3000
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     4.08ms    1.98ms  45.70ms   93.69%
    Req/Sec    12.75k     2.64k   15.01k    85.00%
  253781 requests in 10.00s, 42.35MB read
Requests/sec:  25366.13
Transfer/sec:      4.23MB
 daniel@MBP-daniel  ~/mojo.js   main  wrk -c 100 -d 10s http://127.0.0.1:3000
Running 10s test @ http://127.0.0.1:3000
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.92ms    0.93ms  21.27ms   87.21%
    Req/Sec    12.84k     1.75k   14.44k    85.00%
  255611 requests in 10.00s, 42.66MB read
Requests/sec:  25553.09
Transfer/sec:      4.26MB
 daniel@MBP-daniel  ~/mojo.js   main  wrk -c 100 -d 10s http://127.0.0.1:3000
Running 10s test @ http://127.0.0.1:3000
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.70ms  723.09us  12.59ms   86.18%
    Req/Sec    13.55k     1.42k   15.10k    86.00%
  269772 requests in 10.01s, 45.02MB read
Requests/sec:  26962.37
Transfer/sec:      4.50MB
 daniel@MBP-daniel  ~/mojo.js   main  
```
