### PR TITLE
Update webchat links to web.libera.chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [Mojolicious](https://mojolicious.org) for Node.js. This project is still **under heavy development** and not ready
 for production use yet. If you want to help out, you're welcome to join us on
-[IRC](https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#mojo.js) (`#mojo.js` on Libera.Chat).
+[IRC](https://web.libera.chat/#mojo.js) (`#mojo.js` on Libera.Chat).
 
 ```js
 import mojo from '@mojojs/mojo';

--- a/vendor/views/mojo/debug.html.ejs
+++ b/vendor/views/mojo/debug.html.ejs
@@ -42,7 +42,7 @@
                 Community
               </a>
               <div class="dropdown-menu" aria-labelledby="communityDropdown">
-                <a class="dropdown-item" href="https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#mojo.js">Chat</a>
+                <a class="dropdown-item" href="https://web.libera.chat/#mojo.js">Chat</a>
                 <a class="dropdown-item" href="https://github.com/mojolicious/mojo.js/discussions">Forum</a>
                 <a class="dropdown-item" href="https://twitter.com/mojolicious_org">Twitter</a>
                 <a class="dropdown-item" href="https://blogs.mojolicious.org">Blogs</a>


### PR DESCRIPTION
Use https://web.libera.chat/#mojo.js for webchat links. Ref https://github.com/mojolicious/mojo/pull/1789