### PR TITLE
Make "*" hostname to be a "0.0.0.0"

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -108,13 +108,15 @@ export default class Server {
     const listen = [];
     const params = url.searchParams;
 
-    if (url.port) {
-      listen.push(url.port);
-      if (url.hostname !== '*') listen.push(url.hostname);
+    const port = url.port;
+    if (port !== '') {
+      listen.push(port);
+      const hostname = url.hostname;
+      listen.push(hostname === '*' ? '0.0.0.0' : hostname);
     } else if (params.has('fd')) {
       listen.push({fd: parseInt(params.get('fd'))});
     } else {
-      listen.push(null);
+      listen.push(null, '0.0.0.0');
     }
 
     return listen;


### PR DESCRIPTION
Hello, Sebastian!
I am using mojo.js in my project and as soon as i started to write tests i found some problems with TestClient. It looks like TestClient can not connect to started server because of IPv6 is using be default in Node.

This is an example of error i'm getting now:

```
$ npx tap
 FAIL  test/resource.js
 ✖ connect EADDRNOTAVAIL :::34483 - Local (:::0)

  test: Resource
  at:
    line: 905
    column: 16
    file: node:net
    function: internalConnect
  errno: -99
  code: EADDRNOTAVAIL
  syscall: connect
  address: "::"
  port: 34483
  tapCaught: returnedPromiseRejection
```

I use vscode devcontainers and docker for development. When I start application using cli `server` and go to browser it seems ok even with ipv6.

The test's code is:

```js
import tap from 'tap';
import startup from '../src/startup.js';

tap.test('Resource', async t => {
  const app = await startup();
  const client = await app.newTestClient({tap: t});

  (await client.getOk('/api/1/resource/profiles')).statusIs(200);

  client.stop();
})
```

I think the problem may be caused by docker and it's network setting, but I think it's better for everyone to use ipv4 addresses by default.

I’m eager to receive your feedback.