### PR TITLE
makes the config param in context.ts params() optional

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -102,7 +102,7 @@ class Context extends EventEmitter {
     return this.app.models;
   }
 
-  async params(options: busboy.BusboyConfig): Promise<Params> {
+  async params(options?: busboy.BusboyConfig): Promise<Params> {
     if (this._params === undefined) {
       const req = this.req;
       const params = (this._params = new Params(req.query));


### PR DESCRIPTION
I think the options parameter in the params() method was supposed to be optional, since that parameter is passed into subsequent methods as an optional parameter.  Noticed this when `tsc` croaked when I converted by mojo.js sample into a typescript project.