### PR TITLE
Fix the behavior of urlFileFor and related methods

### DIFF
--- a/src/static.ts
+++ b/src/static.ts
@@ -30,7 +30,7 @@ export class Static {
 
   filePath(path: string): string {
     if (path.startsWith('/')) path = path.replace('/', '');
-    return this.prefix + path;
+    return new Path(this.prefix, path).toString();
   }
 
   isFresh(ctx: MojoContext, options: {etag?: string; lastModified?: Date} = {}): boolean {

--- a/test/plugin-app.js
+++ b/test/plugin-app.js
@@ -71,6 +71,7 @@ Tag2: <%- ctx.tag('div', {class: 'test'}, 'Hello Mojo!') %>
 `;
 
 function tagHelperPluginResult(baseURL) {
+  if (!baseURL.endsWith('/')) baseURL += '/';
   return `
 Favicon: <link rel="icon" href="${baseURL}mojo/favicon.ico">
 Relative script: <script src="${baseURL}foo/bar.js"></script>

--- a/test/static-app.js
+++ b/test/static-app.js
@@ -245,5 +245,31 @@ t.test('Static app', async t => {
       .bodyIs('Route: PUT');
   });
 
+  await t.test('urlFileFor', async () => {
+    (await ua.getOk('/urlForFile?file=hello.txt')).statusIs(200).bodyLike(/\/public\/hello\.txt/);
+
+    (await ua.getOk('/urlForFile?file=%2Fhello.txt')).statusIs(200).bodyLike(/\/public\/hello\.txt/);
+
+    (await ua.getOk('/urlForFile?file=mojo%2Ffavicon.ico')).statusIs(200).bodyLike(/\/public\/mojo\/favicon\.ico/);
+
+    (await ua.getOk('/urlForFile?file=%2Fmojo%2Ffavicon.ico')).statusIs(200).bodyLike(/\/public\/mojo\/favicon\.ico/);
+  });
+
+  await t.test('urlFileFor (path ends with /)', async () => {
+    const old = app.static.path;
+    app.static.path += '/';
+    try {
+      (await ua.getOk('/urlForFile?file=hello.txt')).statusIs(200).bodyLike(/\/public\/hello\.txt/);
+
+      (await ua.getOk('/urlForFile?file=%2Fhello.txt')).statusIs(200).bodyLike(/\/public\/hello\.txt/);
+
+      (await ua.getOk('/urlForFile?file=mojo%2Ffavicon.ico')).statusIs(200).bodyLike(/\/public\/mojo\/favicon\.ico/);
+
+      (await ua.getOk('/urlForFile?file=%2Fmojo%2Ffavicon.ico')).statusIs(200).bodyLike(/\/public\/mojo\/favicon\.ico/);
+    } finally {
+      app.static.path = old;
+    }
+  });
+
   await ua.stop();
 });

--- a/test/support/js/static-app/index.js
+++ b/test/support/js/static-app/index.js
@@ -10,4 +10,6 @@ app.any('/public/hello.txt', async ctx => {
   await ctx.render({text: `Route: ${ctx.req.method}`});
 });
 
+app.any('/urlForFile', ctx => ctx.render({text: ctx.urlForFile(ctx.req.query.get('file'))}));
+
 app.start();


### PR DESCRIPTION
I have no idea if this is the right place for the tests or if the testing for static paths that end in a slash is correct, but at least it demonstrates the point. Notice that it was actually tested in the incorrect behavior, just obfuscated behind the test helper (see below)

![Screen Shot 2021-10-25 at 8 45 16 PM](https://user-images.githubusercontent.com/735765/138796940-0c6b2d13-dee8-47fb-bace-22953aa9ddf4.png)