### PR TITLE
Add required steps for using npx helper

### DIFF
--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -87,6 +87,8 @@ app.start();
 There is also a helper command available to generate a small example application for you.
 
 ```
+$ mkdir myapp && cd myapp
+$ npm i @mojojs/core
 $ npx mojo create-lite-app
 ...
 ```


### PR DESCRIPTION
Clarify mojo.js needs to be installed into the dir to use `npx mojo`.