### PR TITLE
allow ajv coerce types, fixes #63

### DIFF
--- a/src/body/params.ts
+++ b/src/body/params.ts
@@ -7,7 +7,7 @@ export class Params extends URLSearchParams {
   /**
    * Convert parameters into a plain object, useful for validation.
    */
-  toObject(): Record<string, string> {
+  toObject(): Record<string, any> {
     return Object.fromEntries(this);
   }
 }

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -7,7 +7,7 @@ import Ajv from 'ajv';
  * JSON schema validator class.
  */
 export class Validator {
-  _ajv = new Ajv();
+  _ajv = new Ajv({coerceTypes: 'array'});
 
   /**
    * Add JSON schema.


### PR DESCRIPTION
* This PR would allow to pass several common cases that validation fails because types are not coerced by default by ajv.
* Looking on other cool framework that uses ajv for JSON Schema validation, option coerceTypes: 'array' is the one that helps on more common cases (it also allows coercion of a single data to an (expected) array with 1 element).
* This allows to validate numbers passed as query parameters (See #63).
* This PR also redefines toObject() return type so any kind of data could be returned (as we will need after ajv coerced valid data). This allows the following TypeScript version of the documented JSON Schema validation example to compile (and run) ok:
```typescript
import mojo from '@mojojs/core';
const app = mojo();

// GET /form?test=13
app.get('/form', async ctx => {

    // Prepare validation function for schema
    const validate = ctx.schema({
        $id: 'testForm',
        type: 'object',
        properties: {
            test: { type: 'number' }
        },
        required: ['test']
    });

    // Turn request parameters into a plain object
    const params = await ctx.params();
    const testData = params.toObject();

    // Validate request parameters
    const result = validate?.(testData);
    if (result?.isValid === true) {
        await ctx.render({ json: testData });
    } else {
        await ctx.render({ json: { message: 'Validation failed' }, status: 400 });
    }
});

app.start();
```
* This PR also changes test for schema/dynamic as valid if you are expecting a number but receives a string like '123'.
* Also a test with a string that cannot be coerced to a number ('a123') that should fail.