### PR TITLE
add nested decorator and helper capabilities

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -127,6 +127,7 @@ class Context extends EventEmitter {
   stash: Record<string, any> = {};
 
   _flash: SessionData | undefined = undefined;
+  _nestedHelpersCache: Record<string, Record<string, MojoAction>> = {};
   _params: Params | undefined = undefined;
   _session: Record<string, any> | undefined = undefined;
   _ws: WeakRef<WebSocket> | null = null;

--- a/test/app.js
+++ b/test/app.js
@@ -1092,5 +1092,19 @@ t.test('App', async t => {
     t.end();
   });
 
+  t.test('Nested helper depth limit', t => {
+    let result;
+    try {
+      app.addHelper('too.many.indents', function () {
+        throw new Error('Fail!');
+      });
+    } catch (error) {
+      result = error;
+    }
+    t.match(result, /The name "too\.many\.indents" exceeds maximum depth \(2\) for nested helpers/);
+
+    t.end();
+  });
+
   await ua.stop();
 });


### PR DESCRIPTION
Please consider this PR as a way to add nested decorators and / or helpers. It is based on a discussion that take place on Matrix's #mojo Room.

A nested helper would be added like this:

```typescript
app.addHelper('debug.foo.bar', (ctx, str) => {
  ctx.app.log.debug(str);
});
```
Then you will be able to call it in your context, like:
```typescript
app.get('/', async ctx => {
  ctx.debug.foo.bar('home route was just called');
  await ctx.render({text: 'Hello World!'});
});
```