### PR TITLE
simple fix for empty path named route case

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -492,7 +492,7 @@ class Context extends EventEmitter implements ContextEventEmitter {
   }
 
   _urlForPath(path: string, isWebSocket: boolean, options: MojoURLOptions): string {
-    path = this.req.basePath + path;
+    path = this.req.basePath + (path === '' ? '/' : path);
 
     let queryFragment = '';
     if (options.query !== undefined && Object.keys(options.query).length > 0) {

--- a/test/app.js
+++ b/test/app.js
@@ -26,7 +26,7 @@ t.test('App', async t => {
   );
 
   // GET /
-  app.get('/', ctx => ctx.render({text: 'Hello Mojo!'}));
+  app.get('/', ctx => ctx.render({text: 'Hello Mojo!'})).name('root-route');
 
   // GET /☃
   app.get('/☃', ctx => ctx.render({text: 'Hello Snowman!'}));
@@ -478,6 +478,7 @@ t.test('App', async t => {
     const baseURL = ua.server.urls[0];
     (await ua.postOk('/url_for', {form: {target: '/foo'}})).statusIs(200).bodyIs('/foo');
     (await ua.postOk('/url_for', {form: {target: '/foo/bar.txt'}})).statusIs(200).bodyIs('/foo/bar.txt');
+    (await ua.postOk('/url_for', {form: {target: 'root-route'}})).statusIs(200).bodyIs('/');
     (await ua.postOk('/url_for', {form: {target: 'current'}})).statusIs(200).bodyIs('/url_for');
     (await ua.postOk('/url_for', {form: {target: 'current', msg: 'test'}})).statusIs(200).bodyIs('/url_for/test');
     (await ua.postOk('/url_for', {form: {target: 'https://mojolicious.org'}}))


### PR DESCRIPTION
ctx.urlFor() seems to be broken for a root ("/") named route, like in:

```js
app.get('/', ctx => ctx.render({text: 'Hello World'}).name('root-route');
``` 

`ctx.urlFor('root-route')` would return an empty string (''), instead of a single slash string ('/'). That would end provoking problems with tags like `tags.linkTo()`

You can reproduce the problem with this simple one-liner:

```shell
node examples/hello-template.js eval -v 'app.get("/").name("r") && app.newMockContext().tags.linkTo("r")'
```

That will give you a broken html link result of `<a href></a>` instead of the expected `<a href="/"></a>`

Please consider this PR to fix this issue, it just coerces an empty path to be "/" inside ctx._urlForPath() function.

Upon further consideration, it may be better to ensure that the path is specifically an empty string and not any falsy value. For example, `path = path === '' ? '/' : path;`. I would appreciate your feedback on this.

