### PR TITLE
define and use new TapTestLike local dependence

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -7,8 +7,23 @@ import type {Agent} from 'node:http';
 import type {Readable, Stream} from 'node:stream';
 import type {URL} from 'node:url';
 import type {InspectOptions} from 'node:util';
-import type {Test} from 'tap';
 import type {CookieJar} from 'tough-cookie';
+
+export interface TestContext {
+  equal(actual: any, expected: any, message?: string): void;
+  not(actual: any, expected: any, message?: string): void;
+  notMatch(actual: any, pattern: RegExp, message?: string): void;
+  match(actual: any, pattern: RegExp, message?: string): void;
+  same(actual: any, expected: any, message?: string): void;
+  plan(count: number): void;
+  skip(message: string): void;
+  todo(message: string): void;
+  ok(value: any, message?: string): void;
+  end(): void;
+
+  beforeEach(callback: (t: TestContext) => Promise<void>): void;
+  afterEach(callback: () => Promise<void>): void;
+}
 
 export type {JSONValue} from '@mojojs/util';
 
@@ -221,7 +236,7 @@ export interface UserAgentWebSocketOptions extends SharedUserAgentRequestOptions
 
 export type URLTarget = string | [string, MojoURLOptions];
 
-export type TestUserAgentOptions = UserAgentOptions & {tap?: Test};
+export type TestUserAgentOptions = UserAgentOptions & {tap?: TestContext};
 
 export interface ValidationError {
   instancePath: string;

--- a/src/user-agent/test.ts
+++ b/src/user-agent/test.ts
@@ -3,13 +3,13 @@ import type {App} from '../app.js';
 import type {
   JSONValue,
   ServerOptions,
+  TestContext,
   TestUserAgentOptions,
   UserAgentRequestOptions,
   UserAgentWebSocketOptions
 } from '../types.js';
 import type {WebSocket} from '../websocket.js';
 import type {URL} from 'node:url';
-import type {Test} from 'tap';
 import assert from 'node:assert/strict';
 import {on} from 'node:events';
 import {MockUserAgent} from './mock.js';
@@ -23,7 +23,7 @@ type SkipFunction = (...args: any[]) => any;
 // Helper function to add required `TestUserAgent` assert methods
 // that are missing in a `TAP` instance. This is as an intended side effect
 // to ensure compatibility with `TestUserAgent` class below
-function addNodeAssertMethods(tapInstance: Test): void {
+function addNodeAssertMethods(tapInstance: TestContext): void {
   (tapInstance as any).strictEqual = tapInstance.equal.bind(tapInstance);
   (tapInstance as any).notStrictEqual = tapInstance.not.bind(tapInstance);
   (tapInstance as any).doesNotMatch = tapInstance.notMatch.bind(tapInstance);
@@ -39,7 +39,7 @@ export class TestUserAgent extends MockUserAgent {
    */
   body: Buffer = Buffer.from('');
 
-  _assert: typeof assert | Test | undefined = undefined;
+  _assert: typeof assert | TestContext | undefined = undefined;
   _dom: DOM | undefined = undefined;
   _finished: [number, string] | null | undefined = undefined;
   _messages: AsyncIterableIterator<JSONValue> | undefined = undefined;
@@ -372,13 +372,13 @@ export class TestUserAgent extends MockUserAgent {
     return this._dom;
   }
 
-  _prepareTap(tap: Test): void {
+  _prepareTap(tap: TestContext): void {
     addNodeAssertMethods(tap);
     this._assert = tap;
     const subtests = [tap];
     const assert = this._assert;
 
-    assert.beforeEach(async t => {
+    assert.beforeEach(async (t: TestContext) => {
       addNodeAssertMethods(t);
       subtests.push(t);
       this._assert = t;


### PR DESCRIPTION
### Description: This PR attempts to fix the issue described in #160, where the project fails to build after uninstalling tap and @types/tap due to the Test type being imported from tap in types.ts.

## Changes:
Introduced a new TapTestLike type definition locally within the project that contains only the necessary Test type methods required by the framework from Tap (as discussed in the issue).
Replaced the Test type import from tap with the locally defined TapTestLike to decouple from the external tap dependency.

## Reasoning:
This change ensures that the project can build and function without requiring tap or @types/tap, allowing the use of the built-in node:test module for testing.

This solution should resolve #160 while keeping the project free of unnecessary dependencies.

## Caveats:
I couldn't find an easy automatic test for this change. However, you can manually test it by building the project with the modified @mojojs/core framework, which should now build successfully without tap dependencies.
