### PR TITLE
Fix startup hooks exit code (#175)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -501,7 +501,10 @@ export class App {
    */
   async start(command?: string, ...args: string[]): Promise<void> {
     if (this.detectImport === true && process.argv[1] !== Path.callerFile().toString()) return;
-    return this.cli.start(command, ...args).catch(error => this.log.error(error.message));
+    return this.cli.start(command, ...args).catch(error => {
+      this.log.error(error.message);
+      if (this.detectImport !== false) process.exit(1);
+    });
   }
 
   /**

--- a/test/startup-error.js
+++ b/test/startup-error.js
@@ -1,0 +1,60 @@
+import {spawn} from 'node:child_process';
+import Path from '@mojojs/path';
+import t from 'tap';
+
+t.test('Startup error exit code', async t => {
+  await t.test('onStart error exits with code 1', t => {
+    return new Promise(resolve => {
+      const testScript = Path.currentFile().sibling('support', 'js', 'startup-error-app.js').toString();
+      const child = spawn('node', [testScript, 'server'], {
+        stdio: 'pipe'
+      });
+
+      let stderr = '';
+      child.stderr.on('data', data => {
+        stderr += data.toString();
+      });
+
+      // Kill after 2 seconds if it doesn't exit on its own
+      const timeout = setTimeout(() => {
+        child.kill();
+        t.fail('Process did not exit within timeout');
+        resolve();
+      }, 2000);
+
+      child.on('close', code => {
+        clearTimeout(timeout);
+        t.equal(code, 1, 'Process should exit with code 1');
+        t.match(stderr, /Intentional startup error/, 'Error message should be logged');
+        resolve();
+      });
+    });
+  });
+
+  await t.test('server:start hook error exits with code 1', t => {
+    return new Promise(resolve => {
+      const testScript = Path.currentFile().sibling('support', 'js', 'server-start-error-app.js').toString();
+      const child = spawn('node', [testScript, 'server'], {
+        stdio: 'pipe'
+      });
+
+      let stderr = '';
+      child.stderr.on('data', data => {
+        stderr += data.toString();
+      });
+
+      const timeout = setTimeout(() => {
+        child.kill();
+        t.fail('Process did not exit within timeout');
+        resolve();
+      }, 2000);
+
+      child.on('close', code => {
+        clearTimeout(timeout);
+        t.equal(code, 1, 'Process should exit with code 1');
+        t.match(stderr, /server:start hook error/, 'Error message should be logged');
+        resolve();
+      });
+    });
+  });
+});

--- a/test/support/js/server-start-error-app.js
+++ b/test/support/js/server-start-error-app.js
@@ -1,0 +1,11 @@
+import mojo from '../../../lib/core.js';
+
+const app = mojo();
+
+app.get('/', ctx => ctx.render({text: 'Hello World'}));
+
+app.addAppHook('server:start', async () => {
+  throw new Error('server:start hook error');
+});
+
+app.start();

--- a/test/support/js/startup-error-app.js
+++ b/test/support/js/startup-error-app.js
@@ -1,0 +1,11 @@
+import mojo from '../../../lib/core.js';
+
+const app = mojo();
+
+app.get('/', ctx => ctx.render({text: 'Hello World'}));
+
+app.onStart(async () => {
+  throw new Error('Intentional startup error');
+});
+
+app.start();


### PR DESCRIPTION
Fixes #175

Makes startup hooks (onStart, server:start, etc.) exit with code 1 on error instead of 0.

This preserves test compatibility (detectImport: false) and doesn't affect runtime route errors (which correctly return 500).