### PR TITLE
➖ Remove unused @eslint/compat dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "node": ">= 16"
   },
   "dependencies": {
-    "@eslint/compat": "^2.0.0",
     "@mojojs/dom": "^2.1.0",
     "@mojojs/path": "^1.6.0",
     "@mojojs/template": "^2.2.0",


### PR DESCRIPTION
fixes #183

The `@eslint/compat` package was added during the ESLint 9.x migration but is not actually used anywhere in the codebase. All ESLint plugins in this project natively support the flat config format:

- `eslint-plugin-import-x` - flat config native
- `typescript-eslint` v8+ - flat config native  
- `@eslint/js` - flat config native

No compatibility layer needed.
