### PR TITLE
Bump js-yaml from 4.1.0 to 5.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "busboy": "^1.0.0",
     "chalk": "^5.0.0",
     "form-data": "^4.0.0",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^5.2.2",
     "mime-types": "^2.1.30",
     "nopt": "^10.0.0",
     "stack-utils": "^2.0.3",

--- a/src/body.ts
+++ b/src/body.ts
@@ -6,7 +6,7 @@ import {Params} from './body/params.js';
 import {Headers} from './headers.js';
 import DOM from '@mojojs/dom';
 import busboy from 'busboy';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 interface FileUpload {
   fieldname: string;

--- a/src/plugins/yaml-config.ts
+++ b/src/plugins/yaml-config.ts
@@ -1,6 +1,6 @@
 import type {MojoApp, ConfigOptions} from '../types.js';
 import {loadConfig} from './json-config.js';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 /**
  * YAML config plugin.

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -2,7 +2,7 @@ import type {MojoContext, MojoRenderOptions} from './types.js';
 import {promisify} from 'node:util';
 import {gzip} from 'node:zlib';
 import Path from '@mojojs/path';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 interface EngineResult {
   format: string;

--- a/src/user-agent.ts
+++ b/src/user-agent.ts
@@ -8,7 +8,7 @@ import {HTTPSTransport} from './user-agent/transport/https.js';
 import {WSTransport} from './user-agent/transport/ws.js';
 import {AsyncHooks} from '@mojojs/util';
 import FormData from 'form-data';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 interface Upload {
   content: string;

--- a/src/user-agent/test.ts
+++ b/src/user-agent/test.ts
@@ -15,7 +15,7 @@ import {on} from 'node:events';
 import {MockUserAgent} from './mock.js';
 import DOM from '@mojojs/dom';
 import {jsonPointer} from '@mojojs/util';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import StackUtils from 'stack-utils';
 
 type SkipFunction = (...args: any[]) => any;


### PR DESCRIPTION
Supersedes #208

### Summary
Bumps `js-yaml` to `5.2.2` and updates all `js-yaml` imports across the codebase to namespace imports (`import * as yaml from 'js-yaml'`).

### Details
js-yaml v5 dropped its default export, which caused runtime SyntaxErrors when Node loaded the compiled modules during npm test (the TypeScript build itself still passed, since it only type-checks). This PR bumps the version and updates all 5 affected files to namespace imports so the test suite passes cleanly.